### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/src/db/check_isbn.py
+++ b/src/db/check_isbn.py
@@ -205,7 +205,6 @@ def search_ISBN():
                 author = row.get('autore', '').strip()
                 normalized = normalize_isbn(isbn)
 
-                isbn_status = 'invalid'
                 authoritative_isbn = normalized
                 matched_title = ''
                 result = None


### PR DESCRIPTION
Remove the redundant initialization of `isbn_status` at line 208 in `src/db/check_isbn.py`.

Best fix (without changing behavior):
- Keep `authoritative_isbn`, `matched_title`, and `result` initializations.
- Delete only `isbn_status = 'invalid'` before the validation block.
- Leave the existing validation block (lines 213–219) untouched, since it already guarantees assignment in all branches.

This eliminates the dead store flagged by CodeQL while preserving functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._